### PR TITLE
Fix/workflow slides without suppress

### DIFF
--- a/example-targets-workflow/R/packages.R
+++ b/example-targets-workflow/R/packages.R
@@ -1,40 +1,38 @@
-suppressPackageStartupMessages({
-  # Targets
-  library(targets)
-  library(tarchetypes)
+# Targets
+library(targets)
+library(tarchetypes)
 
-  # Packages
-  library(pak)
-  library(renv)
-  options('renv.config.pak.enabled' = TRUE)
+# Packages
+library(pak)
+library(renv)
+options('renv.config.pak.enabled' = TRUE)
 
-  # General
-  library(data.table)
-  library(dplyr)
-  library(janitor)
-  library(rlang)
-  library(usethis)
-  library(fs)
+# General
+library(data.table)
+library(dplyr)
+library(janitor)
+library(rlang)
+library(usethis)
+library(fs)
 
-  # Plots
-  library(ggplot2)
-  library(visNetwork)
+# Plots
+library(ggplot2)
+library(visNetwork)
 
-  # Models
-  library(modelsummary)
+# Models
+library(modelsummary)
 
-  # Testing
-  library(testthat)
+# Testing
+library(testthat)
 
-  # Data
-  library(palmerpenguins)
+# Data
+library(palmerpenguins)
 
-  # Quarto
-  library(quarto)
+# Quarto
+library(quarto)
 
-  # Conflicts
-  library(conflicted)
-  conflicts_prefer(dplyr::filter)
-  conflicts_prefer(dplyr::first)
-  conflicts_prefer(palmerpenguins::penguins_raw)
-})
+# Conflicts
+library(conflicted)
+conflicts_prefer(dplyr::filter)
+conflicts_prefer(dplyr::first)
+conflicts_prefer(palmerpenguins::penguins_raw)

--- a/slides/workflow.qmd
+++ b/slides/workflow.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Example Workflow"
+title: "Example workflow"
 author: Alec L. Robitaille, Isabella C. Richmond
 format: revealjs
 ---
@@ -24,16 +24,11 @@ format: revealjs
 ## What does it look like?
 
 ```{r}
-#| eval: true
-#| echo: false
-#| warning: false
-#| message: false
-
+#| include: false
 setwd('example-targets-workflow')
+vis <- targets::tar_visnetwork(targets_only = TRUE)
+```
 
-library(targets)
-
-tar_visnetwork(targets_only = T)
-
-
+```{r}
+vis
 ```


### PR DESCRIPTION
For the visnetwork print in the slides/workflow.qmd:

- Removes the suppress package startup messages shim with the echo/etc chunk options. 
- Instead just include=FALSE in one chunk, print in the next. 