### PR TITLE
Fix/renv action missing modelsummary

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.lintr$
+^\.github$

--- a/.github/workflows/quarto-render-pages.yaml
+++ b/.github/workflows/quarto-render-pages.yaml
@@ -36,10 +36,7 @@ jobs:
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
+     - uses: r-lib/actions/setup-renv@v2
 
       - uses: quarto-dev/quarto-actions/render@v2
         with:

--- a/.github/workflows/quarto-render-pages.yaml
+++ b/.github/workflows/quarto-render-pages.yaml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: quarto-dev/quarto-actions/setup@v2
       - run: |


### PR DESCRIPTION
Recent quarto/pages run errors on missing package (modelsummary)
[Use renv action instead](https://github.com/r-lib/actions/tree/v2-branch/setup-renv)